### PR TITLE
Make vCluster platform start clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ vcluster use driver docker
 ### Optional: Start vCluster Platform UI
 
 ```bash
-# Start vCluster Platform (optional but recommended)
+# Start vCluster Platform (optional but recommended and required for private / external nodes)
 vcluster platform start
 ```
 


### PR DESCRIPTION
External nodes feature is a huge win over kind and I think a lot of people would try it out reading the README.md. So it makes sense to explain that starting the vcluster platform is required so they don't skip it and are left to find the info later